### PR TITLE
Optimize blog search: lighter payload, capped results, less wasted work

### DIFF
--- a/src/components/ReactComponent/blog/metadata/SearchField/SearchField.tsx
+++ b/src/components/ReactComponent/blog/metadata/SearchField/SearchField.tsx
@@ -5,7 +5,7 @@ import SearchResults from "@react/blog/metadata/SearchField/components/SearchRes
 import SearchStats from "@react/blog/metadata/SearchField/components/SearchStats";
 import SearchTips from "@react/blog/metadata/SearchField/components/SearchTips";
 import { motion } from "framer-motion";
-import { memo, useCallback, useEffect, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import type { Post } from "types/articles";
 
 interface SearchProps {
@@ -19,41 +19,51 @@ const Search = memo(function Search({ posts }: SearchProps) {
 	const [showSearchTips, setShowSearchTips] = useState(false);
 	const [selectedResultIndex, setSelectedResultIndex] = useState(-1);
 
+	// Mirror state into refs so the global keydown listener can stay bound once
+	// instead of being re-registered on every keystroke / result change.
+	const resultsRef = useRef(results);
+	resultsRef.current = results;
+	const selectedIndexRef = useRef(selectedResultIndex);
+	selectedIndexRef.current = selectedResultIndex;
+	const isFocusedRef = useRef(isSearchFocused);
+	isFocusedRef.current = isSearchFocused;
+
 	const handleKeyDown = useCallback(
 		(e: KeyboardEvent) => {
-			if (e.key === "/" && !isSearchFocused) {
+			if (e.key === "/" && !isFocusedRef.current) {
 				e.preventDefault();
-				const searchInput =
-					document.querySelector<HTMLInputElement>("#search-input");
-				searchInput?.focus();
+				document.querySelector<HTMLInputElement>("#search-input")?.focus();
+				return;
 			}
 
-			if (isSearchFocused) {
-				switch (e.key) {
-					case "ArrowDown":
-						e.preventDefault();
-						setSelectedResultIndex((prev) =>
-							prev < results.length - 1 ? prev + 1 : prev,
-						);
-						break;
-					case "ArrowUp":
-						e.preventDefault();
-						setSelectedResultIndex((prev) => (prev > -1 ? prev - 1 : -1));
-						break;
-					case "Enter":
-						if (selectedResultIndex >= 0 && results[selectedResultIndex]) {
-							window.location.href = `/blog/${results[selectedResultIndex].id}`;
-						}
-						break;
-					case "Escape":
-						e.preventDefault();
-						setQuery("");
-						setSelectedResultIndex(-1);
-						break;
+			if (!isFocusedRef.current) return;
+
+			switch (e.key) {
+				case "ArrowDown":
+					e.preventDefault();
+					setSelectedResultIndex((prev) =>
+						prev < resultsRef.current.length - 1 ? prev + 1 : prev,
+					);
+					break;
+				case "ArrowUp":
+					e.preventDefault();
+					setSelectedResultIndex((prev) => (prev > -1 ? prev - 1 : -1));
+					break;
+				case "Enter": {
+					const selected = resultsRef.current[selectedIndexRef.current];
+					if (selected) {
+						window.location.href = `/blog/${selected.id}`;
+					}
+					break;
 				}
+				case "Escape":
+					e.preventDefault();
+					setQuery("");
+					setSelectedResultIndex(-1);
+					break;
 			}
 		},
-		[isSearchFocused, results, selectedResultIndex, setQuery],
+		[setQuery],
 	);
 
 	useEffect(() => {

--- a/src/components/ReactComponent/blog/metadata/SearchField/components/SearchResults.tsx
+++ b/src/components/ReactComponent/blog/metadata/SearchField/components/SearchResults.tsx
@@ -7,8 +7,8 @@ const containerVariants = {
 	visible: {
 		opacity: 1,
 		transition: {
-			delayChildren: 0.1,
-			staggerChildren: 0.05,
+			delayChildren: 0.04,
+			staggerChildren: 0.02,
 		},
 	},
 };

--- a/src/components/ReactComponent/blog/metadata/SearchField/components/SearchStats.tsx
+++ b/src/components/ReactComponent/blog/metadata/SearchField/components/SearchStats.tsx
@@ -23,6 +23,12 @@ const SearchStats = memo(function SearchStats({
 								<span className="font-semibold text-[#bb9af7]">
 									{searchStats.searchTime}ms
 								</span>
+								{searchStats.totalResults > results.length && (
+									<span className="text-[#565f89]">
+										{" "}
+										(showing top {results.length})
+									</span>
+								)}
 							</>
 						) : (
 							<>No results found</>

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,6 +1,6 @@
 // NOTE: Search excludes archived posts to keep results aligned with public blog listings.
 
-import Fuse, { type FuseResultMatch, type IFuseOptions } from "fuse.js";
+import Fuse, { type IFuseOptions } from "fuse.js";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Post } from "types/articles";
 import type { SearchCache, SearchState } from "types/search";
@@ -13,7 +13,9 @@ const MAX_HISTORY_ITEMS = 10;
 const SEARCH_HISTORY_KEY = "search_history";
 const DEBOUNCE_MS = 250;
 const HISTORY_COMMIT_MS = 1000;
-const SCORE_THRESHOLD = 0.6;
+// Cap how many results we render. Fuse already sorts by relevance, so beyond
+// this nothing useful is lost — but it keeps the animated result list cheap.
+const MAX_RENDERED_RESULTS = 30;
 
 // --- Fuse Configuration ---
 // NOTE: `body` is intentionally excluded. Fuzzy-matching full article text
@@ -42,7 +44,6 @@ const FUSE_CONFIG: IFuseOptions<Post> = {
 	],
 	threshold: 0.4,
 	includeScore: true,
-	includeMatches: true,
 	useExtendedSearch: true,
 	ignoreLocation: true,
 	fieldNormWeight: 1.5,
@@ -159,19 +160,6 @@ const saveSearchHistory = (history: string[]): void => {
 	}
 };
 
-// --- Extract matched fields from Fuse results ---
-
-const extractMatchedFields = (
-	matches: readonly FuseResultMatch[] | undefined,
-): string[] => {
-	if (!matches) return [];
-	const fields = new Set<string>();
-	for (const match of matches) {
-		if (match.key) fields.add(match.key);
-	}
-	return Array.from(fields);
-};
-
 // --- Hook ---
 
 const useSearch = (posts: Post[]): SearchState => {
@@ -249,7 +237,7 @@ const useSearch = (posts: Post[]): SearchState => {
 			const fuseResults = fuse.search(processedQuery);
 
 			const scoredResults = fuseResults
-				.filter((r) => r.score != null && r.score < SCORE_THRESHOLD)
+				.filter((r) => r.score != null)
 				.map((r) => ({
 					post: r.item,
 					relevance: calculateRelevance(
@@ -257,25 +245,25 @@ const useSearch = (posts: Post[]): SearchState => {
 						r.item.data.pubDate,
 						intentType,
 					),
-					matchedFields: extractMatchedFields(r.matches),
 				}))
 				.sort((a, b) => b.relevance - a.relevance);
 
-			const rankedPosts = scoredResults.map((r) => r.post);
-			const allMatchedFields = Array.from(
-				new Set(scoredResults.flatMap((r) => r.matchedFields)),
-			);
 			const avgRelevance = scoredResults.length
 				? scoredResults.reduce((sum, r) => sum + r.relevance, 0) /
 					scoredResults.length
 				: 0;
 
+			// Render only the top slice; report the true match count in stats.
+			const rankedPosts = scoredResults
+				.slice(0, MAX_RENDERED_RESULTS)
+				.map((r) => r.post);
+
 			const searchTime = Math.round(performance.now() - startTime);
 			const stats: SearchState["searchStats"] = {
-				totalResults: rankedPosts.length,
+				totalResults: scoredResults.length,
 				searchTime,
 				relevanceScore: avgRelevance,
-				matchedFields: allMatchedFields,
+				matchedFields: [],
 			};
 
 			setResults(rankedPosts);

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -13,8 +13,9 @@ if (!featureFlags.showSearch) {
 	return Astro.redirect("/access-denied");
 }
 
-// Strip `body` before sending to client — full article text is not searched
-// or displayed, so shipping it as serialized JSON wastes significant bandwidth.
+// Project only the fields search/display need before serializing to the client.
+// Full article body, rendered HTML, hero images, and other metadata are neither
+// searched nor shown, so shipping them as inline JSON wastes bandwidth.
 const posts = featureFlags.showBlog
 	? (await getCollection("blog"))
 			.filter(
@@ -23,9 +24,21 @@ const posts = featureFlags.showBlog
 			)
 			.sort(
 				(a: CollectionEntry<"blog">, b: CollectionEntry<"blog">) =>
-					a.data.pubDate.valueOf() - b.data.pubDate.valueOf(),
+					b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
 			)
-			.map((post: CollectionEntry<"blog">) => ({ ...post, body: "" }))
+			.map((post: CollectionEntry<"blog">) => ({
+				id: post.id,
+				collection: post.collection,
+				data: {
+					title: post.data.title,
+					description: post.data.description,
+					pubDate: post.data.pubDate,
+					authorName: post.data.authorName,
+					draft: post.data.draft,
+					archived: post.data.archived,
+					tags: post.data.tags,
+				},
+			}))
 	: [];
 ---
 


### PR DESCRIPTION
Code review + performance pass over the blog search system (`useSearch` hook + `SearchField` and its sub-components). The search was functionally correct and well-structured (module-level LRU cache, debounce, history with shape validation), so these changes target **efficiency and payload**, not bugs.

## Performance / efficiency

1. **Lighter island payload** — `search.astro` spread the entire content entry (`{ ...post }`) for every post into the hydrated island. Now it projects only the fields search and display actually use (`id` + `title`/`description`/`pubDate`/`authorName`/`tags`). Hero images, avatars, series metadata, `updatedDate`, `body`, and rendered HTML no longer ship as inline JSON. Verified in the built `search/index.html` that those fields are gone.
2. **Capped rendered results (30)** — `SearchResults` previously rendered *every* match through framer-motion with `staggerChildren`, so a broad query animated dozens of nodes that revealed seconds apart. Results are now capped (Fuse already sorts by relevance); `SearchStats` shows "showing top N" when the true match count is higher.
3. **Dropped `includeMatches` + matched-fields extraction** — Fuse was tracking match indices and the hook was building a `matchedFields` array on every search, but nothing in the UI ever displayed them. Removed the config flag and the dead work.
4. **Removed a no-op filter** — the `SCORE_THRESHOLD = 0.6` filter never excluded anything because Fuse's `threshold: 0.4` already caps scores lower.
5. **Stable global keydown listener** — the `/`-to-focus + arrow/enter/escape handler was re-registered on `window` on every keystroke and result change. It now reads current state from refs and binds once.
6. Minor: sort posts newest-first and tighten the result-reveal stagger.

## Verification
- `bun run lint` (Biome + tsc) — clean
- `bun run check` (Astro) — 0 errors / 0 warnings / 0 hints
- `bun run build` — succeeds; confirmed the trimmed payload in the built search page

No functional/behavioral regressions: same fuzzy matching, intent detection (date/tag/author), search syntax (`"phrase"`, `-exclude`, `+include`), debounce, caching, and history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search results now display a "showing top N results" indicator when results are limited.

* **Improvements**
  * Enhanced animation timing for search results display.
  * Optimized keyboard navigation responsiveness in the search interface.
  * Improved search result rendering efficiency with capped result display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->