### PR TITLE
Escape JSON-LD across remaining blog pages

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -6,6 +6,7 @@ import Footer from "@astro/footer/Footer.astro";
 import Header from "@astro/header/Header.astro";
 import { featureFlags } from "@config/featureFlag/featureFlag.json";
 import authorConfig from "@config/siteConfig/info.json";
+import { toJsonLd } from "@util/jsonLd";
 
 export const prerender = true;
 
@@ -90,7 +91,7 @@ try {
     <script
       is:inline
       type="application/ld+json"
-      set:html={JSON.stringify({
+      set:html={toJsonLd({
         "@context": "https://schema.org",
         "@type": "Blog",
         name: `${authorConfig.SiteName} Blog`,

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -6,6 +6,7 @@ import Footer from "@astro/footer/Footer.astro";
 import Header from "@astro/header/Header.astro";
 import { featureFlags } from "@config/featureFlag/featureFlag.json";
 import authorConfig from "@config/siteConfig/info.json";
+import { toJsonLd } from "@util/jsonLd";
 
 export const prerender = true;
 
@@ -90,7 +91,7 @@ try {
     <script
       is:inline
       type="application/ld+json"
-      set:html={JSON.stringify({
+      set:html={toJsonLd({
         "@context": "https://schema.org",
         "@type": "Blog",
         name: `${authorConfig.SiteName} Blog - Page ${currentPage}`,

--- a/src/pages/blog/series/[series].astro
+++ b/src/pages/blog/series/[series].astro
@@ -6,6 +6,7 @@ import Footer from "@astro/footer/Footer.astro";
 import Header from "@astro/header/Header.astro";
 import { featureFlags } from "@config/featureFlag/featureFlag.json";
 import authorConfig from "@config/siteConfig/info.json";
+import { toJsonLd } from "@util/jsonLd";
 import {
 	fromSeriesSlug,
 	getAllSeriesMeta,
@@ -82,7 +83,7 @@ const formatDate = (date: Date) =>
     <script
       is:inline
       type="application/ld+json"
-      set:html={JSON.stringify({
+      set:html={toJsonLd({
         "@context": "https://schema.org",
         "@type": "ItemList",
         name: `${seriesTitle} — Article Series`,

--- a/src/pages/blog/series/index.astro
+++ b/src/pages/blog/series/index.astro
@@ -6,6 +6,7 @@ import Footer from "@astro/footer/Footer.astro";
 import Header from "@astro/header/Header.astro";
 import { featureFlags } from "@config/featureFlag/featureFlag.json";
 import authorConfig from "@config/siteConfig/info.json";
+import { toJsonLd } from "@util/jsonLd";
 import { getAllSeriesMeta, getSeriesPosts } from "@util/series";
 
 export const prerender = true;
@@ -43,7 +44,7 @@ const totalSeriesPosts = getSeriesPosts(allPosts).length;
     <script
       is:inline
       type="application/ld+json"
-      set:html={JSON.stringify({
+      set:html={toJsonLd({
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         name: `Article Series | ${authorConfig.SiteName}`,

--- a/src/util/jsonLd.ts
+++ b/src/util/jsonLd.ts
@@ -1,0 +1,13 @@
+/**
+ * Serialize a value to a JSON string safe to inject into a
+ * `<script type="application/ld+json">` block via `set:html`.
+ *
+ * `JSON.stringify` does not escape the `<` character, so content containing
+ * a closing script tag (e.g. inside a post title or description) could
+ * otherwise close the script element early and corrupt the page markup.
+ * Replacing `<` with its `<` unicode escape keeps the output valid JSON
+ * while making it impossible to break out of the element.
+ */
+export function toJsonLd(value: unknown): string {
+	return JSON.stringify(value).replace(/</g, "\\u003c");
+}


### PR DESCRIPTION
Follow-up to the CodeRabbit JSON-LD escaping fix on PR #147. That PR hardened `BlogPostHead.astro`; this applies the same fix to the other structured-data blocks, which also serialize author content (post titles, descriptions, tags, series names) and had the same risk.

## Changes
- Added a shared util `src/util/jsonLd.ts` — `toJsonLd()` escapes `<` as `<` so content containing `</script>` can't break out of the `<script type="application/ld+json">` element (`JSON.stringify` alone doesn't escape angle brackets). Keeps output as valid JSON.
- Routed the JSON-LD blocks through it in:
  - `src/pages/blog/index.astro` (`Blog`)
  - `src/pages/blog/page/[page].astro` (`Blog`)
  - `src/pages/blog/series/index.astro` (`CollectionPage`)
  - `src/pages/blog/series/[series].astro` (`ItemList`)

## Verification
JSON-LD on the blog index and series pages still parses as valid JSON in the build output. `bun run lint` and `bun run build` pass.

## Note
`BlogPostHead.astro` is intentionally **not** touched here — it's already fixed in PR #147 (with a local helper). Once both merge, a tiny follow-up can switch BlogPostHead to import this shared `toJsonLd` for consistency.