### PR TITLE
fix(ci): webhook trigger no longer blocks CI on timeout

### DIFF
--- a/.github/workflows/scarlet-review.yml
+++ b/.github/workflows/scarlet-review.yml
@@ -10,6 +10,10 @@
 #    - HERMES_WEBHOOK_SECRET — Shared secret for signature validation
 # 2. Copy this file to: .github/workflows/scarlet-review.yml
 # 3. That's it! Every PR will now get an automated review.
+#
+# NOTE: The webhook trigger uses continue-on-error so that if the Hermes server
+# is offline or the port is blocked (e.g., Oracle Cloud VCN), the workflow
+# still passes and does not block PR merges. The review will simply be skipped.
 
 name: Scarlet Speedster PR Review
 
@@ -22,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send review trigger to Hermes
+        continue-on-error: true
         env:
           WEBHOOK_URL: ${{ secrets.HERMES_WEBHOOK_URL }}
           WEBHOOK_SECRET: ${{ secrets.HERMES_WEBHOOK_SECRET }}
@@ -32,17 +37,13 @@ jobs:
           fi
 
           # Compute HMAC signature
-          PAYLOAD='{"action":"workflow_trigger","repository":{"full_name":"'"$GITHUB_REPOSITORY"'"},"pull_request":{"number":'"${{ github.event.pull_request.number }}"',"title":"'"${{ github.event.pull_request.title }}"'"}}'
-
-          # For proper signature, we need to send the actual GitHub event payload
-          # GitHub Actions provides the full webhook payload in $GITHUB_EVENT_PATH
           PAYLOAD_BODY=$(cat "$GITHUB_EVENT_PATH")
 
           SIGNATURE=$(echo -n "$PAYLOAD_BODY" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" -binary | xxd -p | sed 's/^/sha256=/')
 
           echo "Triggering review for PR #${{ github.event.pull_request.number }} in $GITHUB_REPOSITORY"
 
-          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+          RESPONSE=$(curl -s -w "\n%{http_code}" --max-time 10 --connect-timeout 5 -X POST \
             -H "Content-Type: application/json" \
             -H "X-GitHub-Event: pull_request" \
             -H "X-Hub-Signature-256: $SIGNATURE" \
@@ -57,5 +58,5 @@ jobs:
           if [ "$HTTP_CODE" = "200" ]; then
             echo "✅ Review triggered successfully"
           else
-            echo "⚠️ Webhook returned $HTTP_CODE — review may not have been triggered"
+            echo "⚠️ Webhook returned $HTTP_CODE — review may not have been triggered (server may be offline or port blocked)"
           fi


### PR DESCRIPTION
## Problem

The `scarlet-review` GitHub Action was failing with **exit code 28 (curl connection timeout)** when the Hermes webhook server on the VPS is unreachable. This happened because:

1. Oracle Cloud VCN blocks port 9876 externally
2. The curl command had no timeout — it hung for 2+ minutes then failed
3. The failed step blocked the entire workflow, preventing PR merges

## Fix

Three changes to `.github/workflows/scarlet-review.yml`:

1. **`continue-on-error: true`** on the webhook step — the workflow passes even if the webhook is unreachable. The review is simply skipped.
2. **`--max-time 10 --connect-timeout 5`** on curl — fails fast in 5 seconds instead of hanging for 2+ minutes.
3. **Cleaned up unused `PAYLOAD` variable** that was never actually sent (the real payload comes from ``).

## Behavior After Fix

| Scenario | Before | After |
|----------|--------|-------|
| Webhook server reachable | ✅ Works | ✅ Works |
| Webhook server offline | ❌ CI fails, blocks merge | ✅ CI passes, review skipped |
| Webhook port blocked (Oracle VCN) | ❌ 2min hang + fail | ✅ 5s timeout, passes |

## Note

To fully restore webhook-triggered reviews, you need to open port 9876 in Oracle Cloud Console → Networking → VCN → Security Lists. But until then, this fix ensures CI doesn't break.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented review workflows from failing when the webhook service is unavailable or blocked.
  * Improved error messaging when the webhook cannot be delivered, making the cause easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->