### PR TITLE
SEO: consolidate canonical blog URLs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -56,6 +56,7 @@ const blogLastmod = buildBlogLastmod();
 
 export default defineConfig({
 	site: "https://www.rafay99.com",
+	trailingSlash: "always",
 	output: "server",
 	image: {
 		remotePatterns: [

--- a/src/components/blog/AIStack.tsx
+++ b/src/components/blog/AIStack.tsx
@@ -81,91 +81,91 @@ const CSS = `
 `;
 
 function useStyles() {
-  useEffect(() => {
-    if (typeof document === "undefined") return;
-    if (document.getElementById(STYLE_ID)) return;
-    const el = document.createElement("style");
-    el.id = STYLE_ID;
-    el.textContent = CSS;
-    document.head.appendChild(el);
-  }, []);
+	useEffect(() => {
+		if (typeof document === "undefined") return;
+		if (document.getElementById(STYLE_ID)) return;
+		const el = document.createElement("style");
+		el.id = STYLE_ID;
+		el.textContent = CSS;
+		document.head.appendChild(el);
+	}, []);
 }
 
 function useInView<T extends HTMLElement>(threshold = 0.35) {
-  const ref = useRef<T | null>(null);
-  const [inView, setInView] = useState(false);
-  useEffect(() => {
-    const node = ref.current;
-    if (!node || typeof IntersectionObserver === "undefined") {
-      setInView(true);
-      return;
-    }
-    const obs = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((e) => {
-          if (e.isIntersecting) {
-            setInView(true);
-            obs.disconnect();
-          }
-        });
-      },
-      { threshold },
-    );
-    obs.observe(node);
-    return () => obs.disconnect();
-  }, [threshold]);
-  return { ref, inView };
+	const ref = useRef<T | null>(null);
+	const [inView, setInView] = useState(false);
+	useEffect(() => {
+		const node = ref.current;
+		if (!node || typeof IntersectionObserver === "undefined") {
+			setInView(true);
+			return;
+		}
+		const obs = new IntersectionObserver(
+			(entries) => {
+				entries.forEach((e) => {
+					if (e.isIntersecting) {
+						setInView(true);
+						obs.disconnect();
+					}
+				});
+			},
+			{ threshold },
+		);
+		obs.observe(node);
+		return () => obs.disconnect();
+	}, [threshold]);
+	return { ref, inView };
 }
 
 const STACK = [
-  {
-    name: "Framework",
-    tag: "LangChain · LlamaIndex",
-    desc: "Building blocks — tools, memory, prompt chains. Libraries you assemble an agent from.",
-    hero: false,
-  },
-  {
-    name: "Orchestrator",
-    tag: "the brain",
-    desc: "The reasoning loop — when to call the model, how to parse it, what to do next.",
-    hero: false,
-  },
-  {
-    name: "Harness",
-    tag: "the hands + the OS",
-    desc: "Tools, memory, context, permissions, hooks. The layer that actually makes the model useful.",
-    hero: true,
-  },
-  {
-    name: "Model",
-    tag: "the engine",
-    desc: "Claude · GPT · DeepSeek · GLM. Raw intelligence. Table stakes.",
-    hero: false,
-  },
+	{
+		name: "Framework",
+		tag: "LangChain · LlamaIndex",
+		desc: "Building blocks — tools, memory, prompt chains. Libraries you assemble an agent from.",
+		hero: false,
+	},
+	{
+		name: "Orchestrator",
+		tag: "the brain",
+		desc: "The reasoning loop — when to call the model, how to parse it, what to do next.",
+		hero: false,
+	},
+	{
+		name: "Harness",
+		tag: "the hands + the OS",
+		desc: "Tools, memory, context, permissions, hooks. The layer that actually makes the model useful.",
+		hero: true,
+	},
+	{
+		name: "Model",
+		tag: "the engine",
+		desc: "Claude · GPT · DeepSeek · GLM. Raw intelligence. Table stakes.",
+		hero: false,
+	},
 ];
 
 export default function AIStack() {
-  useStyles();
-  const { ref, inView } = useInView<HTMLDivElement>();
-  return (
-    <div ref={ref} className={`hx-stack-wrap ${inView ? "hx-in" : ""}`}>
-      <p className="hx-cap">Where the harness sits in the stack</p>
-      <div className="hx-stack">
-        {STACK.map((l, i) => (
-          <div key={l.name}>
-            <div
-              className={`hx-layer hx-drop ${l.hero ? "hx-hero" : ""}`}
-              style={inView ? { animationDelay: `${i * 120}ms` } : undefined}
-            >
-              <h4>
-                {l.name} <span className="hx-tag">{l.tag}</span>
-              </h4>
-              <p>{l.desc}</p>
-            </div>
-            {i < STACK.length - 1 && <div className="hx-arrow">▼</div>}
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+	useStyles();
+	const { ref, inView } = useInView<HTMLDivElement>();
+	return (
+		<div ref={ref} className={`hx-stack-wrap ${inView ? "hx-in" : ""}`}>
+			<p className="hx-cap">Where the harness sits in the stack</p>
+			<div className="hx-stack">
+				{STACK.map((l, i) => (
+					<div key={l.name}>
+						<div
+							className={`hx-layer hx-drop ${l.hero ? "hx-hero" : ""}`}
+							style={inView ? { animationDelay: `${i * 120}ms` } : undefined}
+						>
+							<h4>
+								{l.name} <span className="hx-tag">{l.tag}</span>
+							</h4>
+							<p>{l.desc}</p>
+						</div>
+						{i < STACK.length - 1 && <div className="hx-arrow">▼</div>}
+					</div>
+				))}
+			</div>
+		</div>
+	);
 }

--- a/src/components/blog/BenchmarkJump.tsx
+++ b/src/components/blog/BenchmarkJump.tsx
@@ -76,103 +76,106 @@ const CSS = `
 `;
 
 function useStyles() {
-  useEffect(() => {
-    if (typeof document === "undefined") return;
-    if (document.getElementById(STYLE_ID)) return;
-    const el = document.createElement("style");
-    el.id = STYLE_ID;
-    el.textContent = CSS;
-    document.head.appendChild(el);
-  }, []);
+	useEffect(() => {
+		if (typeof document === "undefined") return;
+		if (document.getElementById(STYLE_ID)) return;
+		const el = document.createElement("style");
+		el.id = STYLE_ID;
+		el.textContent = CSS;
+		document.head.appendChild(el);
+	}, []);
 }
 
 function useInView<T extends HTMLElement>(threshold = 0.35) {
-  const ref = useRef<T | null>(null);
-  const [inView, setInView] = useState(false);
-  useEffect(() => {
-    const node = ref.current;
-    if (!node || typeof IntersectionObserver === "undefined") {
-      setInView(true);
-      return;
-    }
-    const obs = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((e) => {
-          if (e.isIntersecting) {
-            setInView(true);
-            obs.disconnect();
-          }
-        });
-      },
-      { threshold },
-    );
-    obs.observe(node);
-    return () => obs.disconnect();
-  }, [threshold]);
-  return { ref, inView };
+	const ref = useRef<T | null>(null);
+	const [inView, setInView] = useState(false);
+	useEffect(() => {
+		const node = ref.current;
+		if (!node || typeof IntersectionObserver === "undefined") {
+			setInView(true);
+			return;
+		}
+		const obs = new IntersectionObserver(
+			(entries) => {
+				entries.forEach((e) => {
+					if (e.isIntersecting) {
+						setInView(true);
+						obs.disconnect();
+					}
+				});
+			},
+			{ threshold },
+		);
+		obs.observe(node);
+		return () => obs.disconnect();
+	}, [threshold]);
+	return { ref, inView };
 }
 
 export default function BenchmarkJump() {
-  useStyles();
-  const { ref, inView } = useInView<HTMLDivElement>();
-  const [pct, setPct] = useState(52.8);
+	useStyles();
+	const { ref, inView } = useInView<HTMLDivElement>();
+	const [pct, setPct] = useState(52.8);
 
-  useEffect(() => {
-    if (!inView) return;
-    const reduce =
-      typeof window !== "undefined" &&
-      window.matchMedia &&
-      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    if (reduce) {
-      setPct(66.5);
-      return;
-    }
-    const start = performance.now();
-    const from = 52.8;
-    const to = 66.5;
-    let raf = 0;
-    const tick = (now: number) => {
-      const t = Math.min((now - start) / 1300, 1);
-      const eased = 1 - (1 - t) ** 3;
-      setPct(+(from + (to - from) * eased).toFixed(1));
-      if (t < 1) raf = requestAnimationFrame(tick);
-    };
-    raf = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(raf);
-  }, [inView]);
+	useEffect(() => {
+		if (!inView) return;
+		const reduce =
+			typeof window !== "undefined" &&
+			window.matchMedia &&
+			window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+		if (reduce) {
+			setPct(66.5);
+			return;
+		}
+		const start = performance.now();
+		const from = 52.8;
+		const to = 66.5;
+		let raf = 0;
+		const tick = (now: number) => {
+			const t = Math.min((now - start) / 1300, 1);
+			const eased = 1 - (1 - t) ** 3;
+			setPct(+(from + (to - from) * eased).toFixed(1));
+			if (t < 1) raf = requestAnimationFrame(tick);
+		};
+		raf = requestAnimationFrame(tick);
+		return () => cancelAnimationFrame(raf);
+	}, [inView]);
 
-  return (
-    <div ref={ref} className={`hx-bench-wrap ${inView ? "hx-in" : ""}`}>
-      <p className="hx-cap">Same model. Different harness.</p>
-      <div className="hx-bench">
-        <div className="hx-bench-head hx-rise">
-          They changed <span>nothing</span> about the model — only the harness.
-        </div>
+	return (
+		<div ref={ref} className={`hx-bench-wrap ${inView ? "hx-in" : ""}`}>
+			<p className="hx-cap">Same model. Different harness.</p>
+			<div className="hx-bench">
+				<div className="hx-bench-head hx-rise">
+					They changed <span>nothing</span> about the model — only the harness.
+				</div>
 
-        <div className="hx-rise" style={{ transitionDelay: "80ms" }}>
-          <div className="hx-bar-track">
-            <div
-              className="hx-bar-fill"
-              style={{
-                width: inView ? `${((pct - 45) / (75 - 45)) * 100}%` : "0%",
-              }}
-            />
-          </div>
-          <div className="hx-bar-labels">
-            <span>52.8% before</span>
-            <span className="hx-bench-num">{pct.toFixed(1)}%</span>
-            <span>66.5% after</span>
-          </div>
-        </div>
+				<div className="hx-rise" style={{ transitionDelay: "80ms" }}>
+					<div className="hx-bar-track">
+						<div
+							className="hx-bar-fill"
+							style={{
+								width: inView ? `${((pct - 45) / (75 - 45)) * 100}%` : "0%",
+							}}
+						/>
+					</div>
+					<div className="hx-bar-labels">
+						<span>52.8% before</span>
+						<span className="hx-bench-num">{pct.toFixed(1)}%</span>
+						<span>66.5% after</span>
+					</div>
+				</div>
 
-        <div className="hx-bench-row hx-rise" style={{ transitionDelay: "160ms" }}>
-          <span className="hx-bench-chip">−80% tools → better output</span>
-          <span className="hx-bench-sub">
-            Vercel <em>removed</em> most of their agent's tools and the results
-            improved.
-          </span>
-        </div>
-      </div>
-    </div>
-  );
+				<div
+					className="hx-bench-row hx-rise"
+					style={{ transitionDelay: "160ms" }}
+				>
+					<span className="hx-bench-chip">−80% tools → better output</span>
+					<span className="hx-bench-sub">
+						Vercel <em>removed</em> most of their agent's tools and the results
+						improved.
+					</span>
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/src/components/blog/CodeVsTests.tsx
+++ b/src/components/blog/CodeVsTests.tsx
@@ -49,103 +49,113 @@ const CSS = `
 `;
 
 function useStyles(): void {
-  useEffect(() => {
-    if (typeof document === "undefined") return;
-    if (document.getElementById("ts-code-vs-tests-styles")) return;
-    const el = document.createElement("style");
-    el.id = "ts-code-vs-tests-styles";
-    el.textContent = CSS;
-    document.head.appendChild(el);
-  }, []);
+	useEffect(() => {
+		if (typeof document === "undefined") return;
+		if (document.getElementById("ts-code-vs-tests-styles")) return;
+		const el = document.createElement("style");
+		el.id = "ts-code-vs-tests-styles";
+		el.textContent = CSS;
+		document.head.appendChild(el);
+	}, []);
 }
 
-function useInView<T extends HTMLElement>(threshold = 0.3): {
-  ref: RefObject<T | null>;
-  inView: boolean;
+function useInView<T extends HTMLElement>(
+	threshold = 0.3,
+): {
+	ref: RefObject<T | null>;
+	inView: boolean;
 } {
-  const ref = useRef<T | null>(null);
-  const [inView, setInView] = useState(false);
-  useEffect(() => {
-    const node = ref.current;
-    if (!node || typeof IntersectionObserver === "undefined") {
-      setInView(true);
-      return;
-    }
-    const obs = new IntersectionObserver(
-      (entries) => {
-        for (const e of entries) {
-          if (e.isIntersecting) {
-            setInView(true);
-            obs.disconnect();
-          }
-        }
-      },
-      { threshold },
-    );
-    obs.observe(node);
-    return () => obs.disconnect();
-  }, [threshold]);
-  return { ref, inView };
+	const ref = useRef<T | null>(null);
+	const [inView, setInView] = useState(false);
+	useEffect(() => {
+		const node = ref.current;
+		if (!node || typeof IntersectionObserver === "undefined") {
+			setInView(true);
+			return;
+		}
+		const obs = new IntersectionObserver(
+			(entries) => {
+				for (const e of entries) {
+					if (e.isIntersecting) {
+						setInView(true);
+						obs.disconnect();
+					}
+				}
+			},
+			{ threshold },
+		);
+		obs.observe(node);
+		return () => obs.disconnect();
+	}, [threshold]);
+	return { ref, inView };
 }
 
 // Steady rising staircase — the asset that compounds. Static by design.
 const TEST_BARS: readonly number[] = [34, 44, 52, 61, 70, 80, 90];
 
 export default function CodeVsTests() {
-  useStyles();
-  const { ref, inView } = useInView<HTMLDivElement>();
-  const [t, setT] = useState(0);
+	useStyles();
+	const { ref, inView } = useInView<HTMLDivElement>();
+	const [t, setT] = useState(0);
 
-  useEffect(() => {
-    if (!inView) return;
-    const id = setInterval(() => setT((x) => (x + 1) % 60), 90);
-    return () => clearInterval(id);
-  }, [inView]);
+	useEffect(() => {
+		if (!inView) return;
+		const id = setInterval(() => setT((x) => (x + 1) % 60), 90);
+		return () => clearInterval(id);
+	}, [inView]);
 
-  // Code bars: tall + volatile — cheap, disposable, regenerated constantly.
-  const codeBars: number[] = Array.from(
-    { length: 7 },
-    (_, i) => 30 + ((i * 13 + t * 6) % 60),
-  );
+	// Code bars: tall + volatile — cheap, disposable, regenerated constantly.
+	const codeBars: number[] = Array.from(
+		{ length: 7 },
+		(_, i) => 30 + ((i * 13 + t * 6) % 60),
+	);
 
-  return (
-    <div className={`ts ${inView ? "ts-in" : ""}`} ref={ref}>
-      <p className="ts-cap">The value inversion · price per line, over time</p>
-      <div className="ts-scale ts-rise">
-        <div className="ts-col">
-          <div className="ts-col-h">
-            <b>Code</b>
-            <span className="ts-tag cheap">FIREHOSE</span>
-          </div>
-          <div className="ts-bars">
-            {codeBars.map((h, i) => (
-              <div key={i} className="ts-bar code" style={{ height: `${h}%` }} />
-            ))}
-          </div>
-          <div className="ts-col-f">
-            Infinite supply, regenerated on demand. Marginal price{" "}
-            <span className="ts-price down">↓ ~$0</span>. A model rewrites it
-            over a weekend.
-          </div>
-        </div>
+	return (
+		<div className={`ts ${inView ? "ts-in" : ""}`} ref={ref}>
+			<p className="ts-cap">The value inversion · price per line, over time</p>
+			<div className="ts-scale ts-rise">
+				<div className="ts-col">
+					<div className="ts-col-h">
+						<b>Code</b>
+						<span className="ts-tag cheap">FIREHOSE</span>
+					</div>
+					<div className="ts-bars">
+						{codeBars.map((h, i) => (
+							<div
+								key={i}
+								className="ts-bar code"
+								style={{ height: `${h}%` }}
+							/>
+						))}
+					</div>
+					<div className="ts-col-f">
+						Infinite supply, regenerated on demand. Marginal price{" "}
+						<span className="ts-price down">↓ ~$0</span>. A model rewrites it
+						over a weekend.
+					</div>
+				</div>
 
-        <div className="ts-col">
-          <div className="ts-col-h">
-            <b>The test suite</b>
-            <span className="ts-tag moat">MOAT</span>
-          </div>
-          <div className="ts-bars">
-            {TEST_BARS.map((h, i) => (
-              <div key={i} className="ts-bar test" style={{ height: `${h}%` }} />
-            ))}
-          </div>
-          <div className="ts-col-f">
-            Encodes what "correct" means — every bug you ever hit, frozen. Value{" "}
-            <span className="ts-price up">↑ compounds</span>. Nobody can
-            regenerate your scars.
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+				<div className="ts-col">
+					<div className="ts-col-h">
+						<b>The test suite</b>
+						<span className="ts-tag moat">MOAT</span>
+					</div>
+					<div className="ts-bars">
+						{TEST_BARS.map((h, i) => (
+							<div
+								key={i}
+								className="ts-bar test"
+								style={{ height: `${h}%` }}
+							/>
+						))}
+					</div>
+					<div className="ts-col-f">
+						Encodes what "correct" means — every bug you ever hit, frozen. Value{" "}
+						<span className="ts-price up">↑ compounds</span>. Nobody can
+						regenerate your scars.
+					</div>
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/src/components/blog/CodeVsTests.tsx
+++ b/src/components/blog/CodeVsTests.tsx
@@ -92,6 +92,15 @@ function useInView<T extends HTMLElement>(
 
 // Steady rising staircase — the asset that compounds. Static by design.
 const TEST_BARS: readonly number[] = [34, 44, 52, 61, 70, 80, 90];
+const CODE_BAR_IDS = [
+	"code-bar-1",
+	"code-bar-2",
+	"code-bar-3",
+	"code-bar-4",
+	"code-bar-5",
+	"code-bar-6",
+	"code-bar-7",
+] as const;
 
 export default function CodeVsTests() {
 	useStyles();
@@ -105,10 +114,10 @@ export default function CodeVsTests() {
 	}, [inView]);
 
 	// Code bars: tall + volatile — cheap, disposable, regenerated constantly.
-	const codeBars: number[] = Array.from(
-		{ length: 7 },
-		(_, i) => 30 + ((i * 13 + t * 6) % 60),
-	);
+	const codeBars = CODE_BAR_IDS.map((id, i) => ({
+		id,
+		height: 30 + ((i * 13 + t * 6) % 60),
+	}));
 
 	return (
 		<div className={`ts ${inView ? "ts-in" : ""}`} ref={ref}>
@@ -120,11 +129,11 @@ export default function CodeVsTests() {
 						<span className="ts-tag cheap">FIREHOSE</span>
 					</div>
 					<div className="ts-bars">
-						{codeBars.map((h, i) => (
+						{codeBars.map(({ id, height }) => (
 							<div
-								key={i}
+								key={id}
 								className="ts-bar code"
-								style={{ height: `${h}%` }}
+								style={{ height: `${height}%` }}
 							/>
 						))}
 					</div>
@@ -141,11 +150,11 @@ export default function CodeVsTests() {
 						<span className="ts-tag moat">MOAT</span>
 					</div>
 					<div className="ts-bars">
-						{TEST_BARS.map((h, i) => (
+						{TEST_BARS.map((height) => (
 							<div
-								key={i}
+								key={height}
 								className="ts-bar test"
-								style={{ height: `${h}%` }}
+								style={{ height: `${height}%` }}
 							/>
 						))}
 					</div>

--- a/src/components/blog/HarnessAnatomy.tsx
+++ b/src/components/blog/HarnessAnatomy.tsx
@@ -114,108 +114,110 @@ const CSS = `
 `;
 
 function useStyles() {
-  useEffect(() => {
-    if (typeof document === "undefined") return;
-    if (document.getElementById(STYLE_ID)) return;
-    const el = document.createElement("style");
-    el.id = STYLE_ID;
-    el.textContent = CSS;
-    document.head.appendChild(el);
-  }, []);
+	useEffect(() => {
+		if (typeof document === "undefined") return;
+		if (document.getElementById(STYLE_ID)) return;
+		const el = document.createElement("style");
+		el.id = STYLE_ID;
+		el.textContent = CSS;
+		document.head.appendChild(el);
+	}, []);
 }
 
 function useInView<T extends HTMLElement>(threshold = 0.35) {
-  const ref = useRef<T | null>(null);
-  const [inView, setInView] = useState(false);
-  useEffect(() => {
-    const node = ref.current;
-    if (!node || typeof IntersectionObserver === "undefined") {
-      setInView(true);
-      return;
-    }
-    const obs = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((e) => {
-          if (e.isIntersecting) {
-            setInView(true);
-            obs.disconnect();
-          }
-        });
-      },
-      { threshold },
-    );
-    obs.observe(node);
-    return () => obs.disconnect();
-  }, [threshold]);
-  return { ref, inView };
+	const ref = useRef<T | null>(null);
+	const [inView, setInView] = useState(false);
+	useEffect(() => {
+		const node = ref.current;
+		if (!node || typeof IntersectionObserver === "undefined") {
+			setInView(true);
+			return;
+		}
+		const obs = new IntersectionObserver(
+			(entries) => {
+				entries.forEach((e) => {
+					if (e.isIntersecting) {
+						setInView(true);
+						obs.disconnect();
+					}
+				});
+			},
+			{ threshold },
+		);
+		obs.observe(node);
+		return () => obs.disconnect();
+	}, [threshold]);
+	return { ref, inView };
 }
 
 const HARNESS_LAYERS = [
-  ["Permission & Approval", "Can the agent run this command?"],
-  ["Context Engineering", "What should the model see right now?"],
-  ["Tool Orchestration", "Which tools can it call — and which shouldn't it?"],
-  ["Lifecycle Hooks", "Lint on save? Test before commit?"],
-  ["System Instructions", "Read CLAUDE.md on every turn."],
+	["Permission & Approval", "Can the agent run this command?"],
+	["Context Engineering", "What should the model see right now?"],
+	["Tool Orchestration", "Which tools can it call — and which shouldn't it?"],
+	["Lifecycle Hooks", "Lint on save? Test before commit?"],
+	["System Instructions", "Read CLAUDE.md on every turn."],
 ];
 
 export default function HarnessAnatomy() {
-  useStyles();
-  const { ref, inView } = useInView<HTMLDivElement>();
-  return (
-    <div ref={ref} className={`hx-anat-wrap ${inView ? "hx-in" : ""}`}>
-      <p className="hx-cap">Anatomy of a harness</p>
-      <div className="hx-anat">
-        <div className="hx-spine" aria-hidden />
-        {!("matchMedia" in globalThis) ? null : (
-          <div className="hx-pulse" aria-hidden />
-        )}
+	useStyles();
+	const { ref, inView } = useInView<HTMLDivElement>();
+	return (
+		<div ref={ref} className={`hx-anat-wrap ${inView ? "hx-in" : ""}`}>
+			<p className="hx-cap">Anatomy of a harness</p>
+			<div className="hx-anat">
+				<div className="hx-spine" aria-hidden />
+				{!("matchMedia" in globalThis) ? null : (
+					<div className="hx-pulse" aria-hidden />
+				)}
 
-        <div className="hx-zone hx-rise" style={{ transitionDelay: "0ms" }}>
-          <div className="hx-zone-label">You · the user layer</div>
-          <div className="hx-chips">
-            <span className="hx-chip">Terminal / CLI</span>
-            <span className="hx-chip">Desktop / Web</span>
-            <span className="hx-chip">Editor / IDE</span>
-          </div>
-        </div>
+				<div className="hx-zone hx-rise" style={{ transitionDelay: "0ms" }}>
+					<div className="hx-zone-label">You · the user layer</div>
+					<div className="hx-chips">
+						<span className="hx-chip">Terminal / CLI</span>
+						<span className="hx-chip">Desktop / Web</span>
+						<span className="hx-chip">Editor / IDE</span>
+					</div>
+				</div>
 
-        <div
-          className="hx-zone hx-star-zone hx-rise"
-          style={{ transitionDelay: "90ms" }}
-        >
-          <div className="hx-zone-label" style={{ color: "var(--hx-signal)" }}>
-            The harness — where the actual work happens
-          </div>
-          {HARNESS_LAYERS.map(([name, q], i) => (
-            <div
-              className="hx-row"
-              key={name}
-              style={inView ? { animationDelay: `${250 + i * 130}ms` } : undefined}
-            >
-              <span className="hx-row-name hx-mono">{name}</span>
-              <span className="hx-row-q">{q}</span>
-            </div>
-          ))}
-        </div>
+				<div
+					className="hx-zone hx-star-zone hx-rise"
+					style={{ transitionDelay: "90ms" }}
+				>
+					<div className="hx-zone-label" style={{ color: "var(--hx-signal)" }}>
+						The harness — where the actual work happens
+					</div>
+					{HARNESS_LAYERS.map(([name, q], i) => (
+						<div
+							className="hx-row"
+							key={name}
+							style={
+								inView ? { animationDelay: `${250 + i * 130}ms` } : undefined
+							}
+						>
+							<span className="hx-row-name hx-mono">{name}</span>
+							<span className="hx-row-q">{q}</span>
+						</div>
+					))}
+				</div>
 
-        <div className="hx-zone hx-rise" style={{ transitionDelay: "180ms" }}>
-          <div className="hx-zone-label">The model layer</div>
-          <div className="hx-chips">
-            <span className="hx-chip">
-              LLM — Claude · GPT · DeepSeek · GLM · Kimi…
-            </span>
-          </div>
-        </div>
+				<div className="hx-zone hx-rise" style={{ transitionDelay: "180ms" }}>
+					<div className="hx-zone-label">The model layer</div>
+					<div className="hx-chips">
+						<span className="hx-chip">
+							LLM — Claude · GPT · DeepSeek · GLM · Kimi…
+						</span>
+					</div>
+				</div>
 
-        <div className="hx-zone hx-rise" style={{ transitionDelay: "270ms" }}>
-          <div className="hx-zone-label">The outside world</div>
-          <div className="hx-chips">
-            <span className="hx-chip">File system</span>
-            <span className="hx-chip">Network</span>
-            <span className="hx-chip">MCP servers</span>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+				<div className="hx-zone hx-rise" style={{ transitionDelay: "270ms" }}>
+					<div className="hx-zone-label">The outside world</div>
+					<div className="hx-chips">
+						<span className="hx-chip">File system</span>
+						<span className="hx-chip">Network</span>
+						<span className="hx-chip">MCP servers</span>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/src/components/blog/HarnessLoop.tsx
+++ b/src/components/blog/HarnessLoop.tsx
@@ -100,6 +100,10 @@ function useInView<T extends HTMLElement>(threshold = 0.35) {
 	return { ref, inView };
 }
 
+const NODE_KEYS = ["user", "harness", "model", "tools"] as const;
+type NodeKey = (typeof NODE_KEYS)[number];
+type LoopStep = { text: string; from: NodeKey; to: NodeKey };
+
 const LOOP_STEPS = [
 	{ text: "You send a request.", from: "user", to: "harness" },
 	{
@@ -142,9 +146,9 @@ const LOOP_STEPS = [
 		from: "harness",
 		to: "user",
 	},
-];
+] as const satisfies readonly LoopStep[];
 
-const NODE_POS: Record<string, { x: number; y: number; label: string }> = {
+const NODE_POS: Record<NodeKey, { x: number; y: number; label: string }> = {
 	user: { x: 70, y: 130, label: "YOU" },
 	harness: { x: 250, y: 130, label: "HARNESS" },
 	model: { x: 430, y: 70, label: "MODEL" },
@@ -170,7 +174,8 @@ export default function HarnessLoop() {
 		return () => clearInterval(id);
 	}, [inView]);
 
-	const s = LOOP_STEPS[step];
+	const s = LOOP_STEPS[step] ?? LOOP_STEPS[0];
+	if (!s) return null;
 	const active = new Set([s.from, s.to]);
 	const target = NODE_POS[s.to];
 
@@ -183,19 +188,22 @@ export default function HarnessLoop() {
 				role="img"
 				aria-label="Harness runtime loop"
 			>
-				{(["user", "model", "tools"] as const).map((k) => (
-					<line
-						key={k}
-						x1={NODE_POS.harness.x}
-						y1={NODE_POS.harness.y}
-						x2={NODE_POS[k].x}
-						y2={NODE_POS[k].y}
-						stroke={active.has(k) ? "var(--hx-signal)" : "var(--hx-line)"}
-						strokeWidth={active.has(k) ? 2 : 1.4}
-					/>
-				))}
+				{(["user", "model", "tools"] as const satisfies readonly NodeKey[]).map(
+					(k) => (
+						<line
+							key={k}
+							x1={NODE_POS.harness.x}
+							y1={NODE_POS.harness.y}
+							x2={NODE_POS[k].x}
+							y2={NODE_POS[k].y}
+							stroke={active.has(k) ? "var(--hx-signal)" : "var(--hx-line)"}
+							strokeWidth={active.has(k) ? 2 : 1.4}
+						/>
+					),
+				)}
 
-				{Object.entries(NODE_POS).map(([k, p]) => {
+				{NODE_KEYS.map((k) => {
+					const p = NODE_POS[k];
 					const on = active.has(k);
 					const isHub = k === "harness";
 					return (

--- a/src/components/blog/HarnessLoop.tsx
+++ b/src/components/blog/HarnessLoop.tsx
@@ -64,189 +64,189 @@ const CSS = `
 `;
 
 function useStyles() {
-  useEffect(() => {
-    if (typeof document === "undefined") return;
-    if (document.getElementById(STYLE_ID)) return;
-    const el = document.createElement("style");
-    el.id = STYLE_ID;
-    el.textContent = CSS;
-    document.head.appendChild(el);
-  }, []);
+	useEffect(() => {
+		if (typeof document === "undefined") return;
+		if (document.getElementById(STYLE_ID)) return;
+		const el = document.createElement("style");
+		el.id = STYLE_ID;
+		el.textContent = CSS;
+		document.head.appendChild(el);
+	}, []);
 }
 
 function useInView<T extends HTMLElement>(threshold = 0.35) {
-  const ref = useRef<T | null>(null);
-  const [inView, setInView] = useState(false);
-  useEffect(() => {
-    const node = ref.current;
-    if (!node || typeof IntersectionObserver === "undefined") {
-      setInView(true);
-      return;
-    }
-    const obs = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((e) => {
-          if (e.isIntersecting) {
-            setInView(true);
-            obs.disconnect();
-          }
-        });
-      },
-      { threshold },
-    );
-    obs.observe(node);
-    return () => obs.disconnect();
-  }, [threshold]);
-  return { ref, inView };
+	const ref = useRef<T | null>(null);
+	const [inView, setInView] = useState(false);
+	useEffect(() => {
+		const node = ref.current;
+		if (!node || typeof IntersectionObserver === "undefined") {
+			setInView(true);
+			return;
+		}
+		const obs = new IntersectionObserver(
+			(entries) => {
+				entries.forEach((e) => {
+					if (e.isIntersecting) {
+						setInView(true);
+						obs.disconnect();
+					}
+				});
+			},
+			{ threshold },
+		);
+		obs.observe(node);
+		return () => obs.disconnect();
+	}, [threshold]);
+	return { ref, inView };
 }
 
 const LOOP_STEPS = [
-  { text: "You send a request.", from: "user", to: "harness" },
-  {
-    text: "The harness curates context — system prompt, history, docs.",
-    from: "harness",
-    to: "harness",
-  },
-  {
-    text: "It hands the curated context to the model.",
-    from: "harness",
-    to: "model",
-  },
-  {
-    text: "The model answers. It never touches the outside world itself.",
-    from: "model",
-    to: "harness",
-  },
-  {
-    text: "The harness verifies the output — format, safety.",
-    from: "harness",
-    to: "harness",
-  },
-  {
-    text: "It executes the tools the model asked for.",
-    from: "harness",
-    to: "tools",
-  },
-  {
-    text: "Tool results come back into the harness.",
-    from: "tools",
-    to: "harness",
-  },
-  {
-    text: "Results are fed back to the model for the next move.",
-    from: "harness",
-    to: "model",
-  },
-  {
-    text: "The finished result is delivered to you.",
-    from: "harness",
-    to: "user",
-  },
+	{ text: "You send a request.", from: "user", to: "harness" },
+	{
+		text: "The harness curates context — system prompt, history, docs.",
+		from: "harness",
+		to: "harness",
+	},
+	{
+		text: "It hands the curated context to the model.",
+		from: "harness",
+		to: "model",
+	},
+	{
+		text: "The model answers. It never touches the outside world itself.",
+		from: "model",
+		to: "harness",
+	},
+	{
+		text: "The harness verifies the output — format, safety.",
+		from: "harness",
+		to: "harness",
+	},
+	{
+		text: "It executes the tools the model asked for.",
+		from: "harness",
+		to: "tools",
+	},
+	{
+		text: "Tool results come back into the harness.",
+		from: "tools",
+		to: "harness",
+	},
+	{
+		text: "Results are fed back to the model for the next move.",
+		from: "harness",
+		to: "model",
+	},
+	{
+		text: "The finished result is delivered to you.",
+		from: "harness",
+		to: "user",
+	},
 ];
 
 const NODE_POS: Record<string, { x: number; y: number; label: string }> = {
-  user: { x: 70, y: 130, label: "YOU" },
-  harness: { x: 250, y: 130, label: "HARNESS" },
-  model: { x: 430, y: 70, label: "MODEL" },
-  tools: { x: 430, y: 190, label: "TOOLS" },
+	user: { x: 70, y: 130, label: "YOU" },
+	harness: { x: 250, y: 130, label: "HARNESS" },
+	model: { x: 430, y: 70, label: "MODEL" },
+	tools: { x: 430, y: 190, label: "TOOLS" },
 };
 
 export default function HarnessLoop() {
-  useStyles();
-  const { ref, inView } = useInView<HTMLDivElement>();
-  const [step, setStep] = useState(0);
+	useStyles();
+	const { ref, inView } = useInView<HTMLDivElement>();
+	const [step, setStep] = useState(0);
 
-  useEffect(() => {
-    if (!inView) return;
-    const reduce =
-      typeof window !== "undefined" &&
-      window.matchMedia &&
-      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    if (reduce) return;
-    const id = setInterval(
-      () => setStep((s) => (s + 1) % LOOP_STEPS.length),
-      1500,
-    );
-    return () => clearInterval(id);
-  }, [inView]);
+	useEffect(() => {
+		if (!inView) return;
+		const reduce =
+			typeof window !== "undefined" &&
+			window.matchMedia &&
+			window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+		if (reduce) return;
+		const id = setInterval(
+			() => setStep((s) => (s + 1) % LOOP_STEPS.length),
+			1500,
+		);
+		return () => clearInterval(id);
+	}, [inView]);
 
-  const s = LOOP_STEPS[step];
-  const active = new Set([s.from, s.to]);
-  const target = NODE_POS[s.to];
+	const s = LOOP_STEPS[step];
+	const active = new Set([s.from, s.to]);
+	const target = NODE_POS[s.to];
 
-  return (
-    <div ref={ref} className={`hx-loop-wrap ${inView ? "hx-in" : ""}`}>
-      <p className="hx-cap">The loop that runs on every single prompt</p>
-      <svg
-        viewBox="0 0 500 260"
-        width="100%"
-        role="img"
-        aria-label="Harness runtime loop"
-      >
-        {(["user", "model", "tools"] as const).map((k) => (
-          <line
-            key={k}
-            x1={NODE_POS.harness.x}
-            y1={NODE_POS.harness.y}
-            x2={NODE_POS[k].x}
-            y2={NODE_POS[k].y}
-            stroke={active.has(k) ? "var(--hx-signal)" : "var(--hx-line)"}
-            strokeWidth={active.has(k) ? 2 : 1.4}
-          />
-        ))}
+	return (
+		<div ref={ref} className={`hx-loop-wrap ${inView ? "hx-in" : ""}`}>
+			<p className="hx-cap">The loop that runs on every single prompt</p>
+			<svg
+				viewBox="0 0 500 260"
+				width="100%"
+				role="img"
+				aria-label="Harness runtime loop"
+			>
+				{(["user", "model", "tools"] as const).map((k) => (
+					<line
+						key={k}
+						x1={NODE_POS.harness.x}
+						y1={NODE_POS.harness.y}
+						x2={NODE_POS[k].x}
+						y2={NODE_POS[k].y}
+						stroke={active.has(k) ? "var(--hx-signal)" : "var(--hx-line)"}
+						strokeWidth={active.has(k) ? 2 : 1.4}
+					/>
+				))}
 
-        {Object.entries(NODE_POS).map(([k, p]) => {
-          const on = active.has(k);
-          const isHub = k === "harness";
-          return (
-            <g key={k}>
-              <circle
-                cx={p.x}
-                cy={p.y}
-                r={isHub ? 42 : 30}
-                fill="var(--hx-panel)"
-                stroke={on || isHub ? "var(--hx-signal)" : "var(--hx-line)"}
-                strokeWidth={isHub ? 2 : 1.5}
-                style={
-                  isHub
-                    ? { filter: "drop-shadow(0 0 10px var(--hx-glow))" }
-                    : on
-                      ? { filter: "drop-shadow(0 0 6px var(--hx-glow))" }
-                      : undefined
-                }
-              />
-              <text
-                x={p.x}
-                y={p.y + 4}
-                textAnchor="middle"
-                className={`hx-node-label ${on || isHub ? "hx-on" : ""}`}
-              >
-                {p.label}
-              </text>
-            </g>
-          );
-        })}
+				{Object.entries(NODE_POS).map(([k, p]) => {
+					const on = active.has(k);
+					const isHub = k === "harness";
+					return (
+						<g key={k}>
+							<circle
+								cx={p.x}
+								cy={p.y}
+								r={isHub ? 42 : 30}
+								fill="var(--hx-panel)"
+								stroke={on || isHub ? "var(--hx-signal)" : "var(--hx-line)"}
+								strokeWidth={isHub ? 2 : 1.5}
+								style={
+									isHub
+										? { filter: "drop-shadow(0 0 10px var(--hx-glow))" }
+										: on
+											? { filter: "drop-shadow(0 0 6px var(--hx-glow))" }
+											: undefined
+								}
+							/>
+							<text
+								x={p.x}
+								y={p.y + 4}
+								textAnchor="middle"
+								className={`hx-node-label ${on || isHub ? "hx-on" : ""}`}
+							>
+								{p.label}
+							</text>
+						</g>
+					);
+				})}
 
-        <g
-          style={{
-            transform: `translate(${target.x}px, ${target.y}px)`,
-            transition: "transform .7s cubic-bezier(.5,0,.4,1)",
-          }}
-        >
-          <circle
-            r={6}
-            fill="var(--hx-signal-2)"
-            style={{ filter: "drop-shadow(0 0 8px var(--hx-glow))" }}
-          />
-        </g>
-      </svg>
+				<g
+					style={{
+						transform: `translate(${target.x}px, ${target.y}px)`,
+						transition: "transform .7s cubic-bezier(.5,0,.4,1)",
+					}}
+				>
+					<circle
+						r={6}
+						fill="var(--hx-signal-2)"
+						style={{ filter: "drop-shadow(0 0 8px var(--hx-glow))" }}
+					/>
+				</g>
+			</svg>
 
-      <div className="hx-loop-caption">
-        <span className="hx-loop-step">
-          {step + 1} / {LOOP_STEPS.length}
-        </span>
-        <span className="hx-loop-text">{s.text}</span>
-      </div>
-    </div>
-  );
+			<div className="hx-loop-caption">
+				<span className="hx-loop-step">
+					{step + 1} / {LOOP_STEPS.length}
+				</span>
+				<span className="hx-loop-text">{s.text}</span>
+			</div>
+		</div>
+	);
 }

--- a/src/components/blog/MigrationLoop.tsx
+++ b/src/components/blog/MigrationLoop.tsx
@@ -8,11 +8,11 @@ import { type RefObject, useEffect, useRef, useState } from "react";
 type Verdict = "pass" | "fail" | null;
 
 interface LoopFrame {
-  /** Index of the node currently lit: 0 gen · 1 build · 2 test · 3 fix · 6 merge. */
-  active: number;
-  verdict: Verdict;
-  /** Show the "failing test → next work item" back-route hint. */
-  back: boolean;
+	/** Index of the node currently lit: 0 gen · 1 build · 2 test · 3 fix · 6 merge. */
+	active: number;
+	verdict: Verdict;
+	/** Show the "failing test → next work item" back-route hint. */
+	back: boolean;
 }
 
 const CSS = `
@@ -69,134 +69,138 @@ const CSS = `
 `;
 
 function useStyles(): void {
-  useEffect(() => {
-    if (typeof document === "undefined") return;
-    if (document.getElementById("ts-migration-loop-styles")) return;
-    const el = document.createElement("style");
-    el.id = "ts-migration-loop-styles";
-    el.textContent = CSS;
-    document.head.appendChild(el);
-  }, []);
+	useEffect(() => {
+		if (typeof document === "undefined") return;
+		if (document.getElementById("ts-migration-loop-styles")) return;
+		const el = document.createElement("style");
+		el.id = "ts-migration-loop-styles";
+		el.textContent = CSS;
+		document.head.appendChild(el);
+	}, []);
 }
 
-function useInView<T extends HTMLElement>(threshold = 0.3): {
-  ref: RefObject<T | null>;
-  inView: boolean;
+function useInView<T extends HTMLElement>(
+	threshold = 0.3,
+): {
+	ref: RefObject<T | null>;
+	inView: boolean;
 } {
-  const ref = useRef<T | null>(null);
-  const [inView, setInView] = useState(false);
-  useEffect(() => {
-    const node = ref.current;
-    if (!node || typeof IntersectionObserver === "undefined") {
-      setInView(true);
-      return;
-    }
-    const obs = new IntersectionObserver(
-      (entries) => {
-        for (const e of entries) {
-          if (e.isIntersecting) {
-            setInView(true);
-            obs.disconnect();
-          }
-        }
-      },
-      { threshold },
-    );
-    obs.observe(node);
-    return () => obs.disconnect();
-  }, [threshold]);
-  return { ref, inView };
+	const ref = useRef<T | null>(null);
+	const [inView, setInView] = useState(false);
+	useEffect(() => {
+		const node = ref.current;
+		if (!node || typeof IntersectionObserver === "undefined") {
+			setInView(true);
+			return;
+		}
+		const obs = new IntersectionObserver(
+			(entries) => {
+				for (const e of entries) {
+					if (e.isIntersecting) {
+						setInView(true);
+						obs.disconnect();
+					}
+				}
+			},
+			{ threshold },
+		);
+		obs.observe(node);
+		return () => obs.disconnect();
+	}, [threshold]);
+	return { ref, inView };
 }
 
 const IDLE: LoopFrame = { active: 0, verdict: null, back: false };
 
 // gen → build → test(fail) → fix → build → test(pass) → merge
 const LOOP_FRAMES: readonly LoopFrame[] = [
-  { active: 0, verdict: null, back: false },
-  { active: 1, verdict: null, back: false },
-  { active: 2, verdict: "fail", back: false },
-  { active: 3, verdict: "fail", back: true },
-  { active: 1, verdict: null, back: false },
-  { active: 2, verdict: "pass", back: false },
-  { active: 6, verdict: "pass", back: false },
+	{ active: 0, verdict: null, back: false },
+	{ active: 1, verdict: null, back: false },
+	{ active: 2, verdict: "fail", back: false },
+	{ active: 3, verdict: "fail", back: true },
+	{ active: 1, verdict: null, back: false },
+	{ active: 2, verdict: "pass", back: false },
+	{ active: 6, verdict: "pass", back: false },
 ];
 
 export default function MigrationLoop() {
-  useStyles();
-  const { ref, inView } = useInView<HTMLDivElement>();
-  const [f, setF] = useState(0);
+	useStyles();
+	const { ref, inView } = useInView<HTMLDivElement>();
+	const [f, setF] = useState(0);
 
-  useEffect(() => {
-    if (!inView) return;
-    const id = setInterval(
-      () => setF((x) => (x + 1) % LOOP_FRAMES.length),
-      1300,
-    );
-    return () => clearInterval(id);
-  }, [inView]);
+	useEffect(() => {
+		if (!inView) return;
+		const id = setInterval(
+			() => setF((x) => (x + 1) % LOOP_FRAMES.length),
+			1300,
+		);
+		return () => clearInterval(id);
+	}, [inView]);
 
-  const frame: LoopFrame = LOOP_FRAMES[f] ?? IDLE;
+	const frame: LoopFrame = LOOP_FRAMES[f] ?? IDLE;
 
-  const nodeClass = (i: number): string => {
-    if (frame.active !== i) return "ts-node";
-    if (i === 2) return `ts-node ${frame.verdict === "pass" ? "pass" : "fail"}`;
-    if (i === 6) return "ts-node pass";
-    return "ts-node on";
-  };
+	const nodeClass = (i: number): string => {
+		if (frame.active !== i) return "ts-node";
+		if (i === 2) return `ts-node ${frame.verdict === "pass" ? "pass" : "fail"}`;
+		if (i === 6) return "ts-node pass";
+		return "ts-node on";
+	};
 
-  return (
-    <div className={`ts ${inView ? "ts-in" : ""}`} ref={ref}>
-      <p className="ts-cap">The loop · code is guilty until the suite says otherwise</p>
-      <div className="ts-loop ts-rise">
-        <div className="ts-loop-row">
-          <div className={nodeClass(0)}>
-            <div className="ts-node-k">01</div>
-            <div className="ts-node-t">Generate</div>
-            <div className="ts-node-n">agent writes the port</div>
-          </div>
-          <div className={`ts-arrow ${frame.active <= 1 ? "hot" : ""}`}>▸</div>
-          <div className={nodeClass(1)}>
-            <div className="ts-node-k">02</div>
-            <div className="ts-node-t">Build</div>
-            <div className="ts-node-n">does it compile?</div>
-          </div>
-          <div className={`ts-arrow ${frame.active === 2 ? "hot" : ""}`}>▸</div>
-          <div className={nodeClass(2)}>
-            <div className="ts-node-k">03</div>
-            <div className="ts-node-t">Run the suite</div>
-            <div className="ts-node-n">the ground truth</div>
-          </div>
-        </div>
+	return (
+		<div className={`ts ${inView ? "ts-in" : ""}`} ref={ref}>
+			<p className="ts-cap">
+				The loop · code is guilty until the suite says otherwise
+			</p>
+			<div className="ts-loop ts-rise">
+				<div className="ts-loop-row">
+					<div className={nodeClass(0)}>
+						<div className="ts-node-k">01</div>
+						<div className="ts-node-t">Generate</div>
+						<div className="ts-node-n">agent writes the port</div>
+					</div>
+					<div className={`ts-arrow ${frame.active <= 1 ? "hot" : ""}`}>▸</div>
+					<div className={nodeClass(1)}>
+						<div className="ts-node-k">02</div>
+						<div className="ts-node-t">Build</div>
+						<div className="ts-node-n">does it compile?</div>
+					</div>
+					<div className={`ts-arrow ${frame.active === 2 ? "hot" : ""}`}>▸</div>
+					<div className={nodeClass(2)}>
+						<div className="ts-node-k">03</div>
+						<div className="ts-node-t">Run the suite</div>
+						<div className="ts-node-n">the ground truth</div>
+					</div>
+				</div>
 
-        <div className={`ts-gate ${frame.verdict ?? ""}`}>
-          <span className="ts-gate-label">Test gate</span>
-          <span className={`ts-verdict ${frame.verdict ?? ""}`}>
-            {frame.verdict === "pass"
-              ? "✓ 100% green — ship it"
-              : frame.verdict === "fail"
-                ? "✗ red — send it back"
-                : "· awaiting run"}
-          </span>
-        </div>
+				<div className={`ts-gate ${frame.verdict ?? ""}`}>
+					<span className="ts-gate-label">Test gate</span>
+					<span className={`ts-verdict ${frame.verdict ?? ""}`}>
+						{frame.verdict === "pass"
+							? "✓ 100% green — ship it"
+							: frame.verdict === "fail"
+								? "✗ red — send it back"
+								: "· awaiting run"}
+					</span>
+				</div>
 
-        <div className={`ts-back ${frame.back ? "show" : ""}`}>
-          ↑ failing test becomes the next work item → Fix → Build again
-        </div>
+				<div className={`ts-back ${frame.back ? "show" : ""}`}>
+					↑ failing test becomes the next work item → Fix → Build again
+				</div>
 
-        <div className="ts-loop-row">
-          <div className={nodeClass(3)}>
-            <div className="ts-node-k">04</div>
-            <div className="ts-node-t">Fix</div>
-            <div className="ts-node-n">re-prompt with the error</div>
-          </div>
-          <div className="ts-arrow">▸</div>
-          <div className={nodeClass(6)}>
-            <div className="ts-node-k">05</div>
-            <div className="ts-node-t">Merge</div>
-            <div className="ts-node-n">only a green suite gets here</div>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+				<div className="ts-loop-row">
+					<div className={nodeClass(3)}>
+						<div className="ts-node-k">04</div>
+						<div className="ts-node-t">Fix</div>
+						<div className="ts-node-n">re-prompt with the error</div>
+					</div>
+					<div className="ts-arrow">▸</div>
+					<div className={nodeClass(6)}>
+						<div className="ts-node-k">05</div>
+						<div className="ts-node-t">Merge</div>
+						<div className="ts-node-n">only a green suite gets here</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/src/components/blog/SpecSurvivesPort.tsx
+++ b/src/components/blog/SpecSurvivesPort.tsx
@@ -2,12 +2,11 @@
  * Edits to this file are overwritten on the next publish; edit the
  * animation inside Wryte instead. */
 
-
 import { type RefObject, useEffect, useRef, useState } from "react";
 
 interface Port {
-  name: string;
-  sub: string;
+	name: string;
+	sub: string;
 }
 
 const CSS = `
@@ -56,85 +55,87 @@ const CSS = `
 `;
 
 function useStyles(): void {
-  useEffect(() => {
-    if (typeof document === "undefined") return;
-    if (document.getElementById("ts-spec-survives-styles")) return;
-    const el = document.createElement("style");
-    el.id = "ts-spec-survives-styles";
-    el.textContent = CSS;
-    document.head.appendChild(el);
-  }, []);
+	useEffect(() => {
+		if (typeof document === "undefined") return;
+		if (document.getElementById("ts-spec-survives-styles")) return;
+		const el = document.createElement("style");
+		el.id = "ts-spec-survives-styles";
+		el.textContent = CSS;
+		document.head.appendChild(el);
+	}, []);
 }
 
-function useInView<T extends HTMLElement>(threshold = 0.3): {
-  ref: RefObject<T | null>;
-  inView: boolean;
+function useInView<T extends HTMLElement>(
+	threshold = 0.3,
+): {
+	ref: RefObject<T | null>;
+	inView: boolean;
 } {
-  const ref = useRef<T | null>(null);
-  const [inView, setInView] = useState(false);
-  useEffect(() => {
-    const node = ref.current;
-    if (!node || typeof IntersectionObserver === "undefined") {
-      setInView(true);
-      return;
-    }
-    const obs = new IntersectionObserver(
-      (entries) => {
-        for (const e of entries) {
-          if (e.isIntersecting) {
-            setInView(true);
-            obs.disconnect();
-          }
-        }
-      },
-      { threshold },
-    );
-    obs.observe(node);
-    return () => obs.disconnect();
-  }, [threshold]);
-  return { ref, inView };
+	const ref = useRef<T | null>(null);
+	const [inView, setInView] = useState(false);
+	useEffect(() => {
+		const node = ref.current;
+		if (!node || typeof IntersectionObserver === "undefined") {
+			setInView(true);
+			return;
+		}
+		const obs = new IntersectionObserver(
+			(entries) => {
+				for (const e of entries) {
+					if (e.isIntersecting) {
+						setInView(true);
+						obs.disconnect();
+					}
+				}
+			},
+			{ threshold },
+		);
+		obs.observe(node);
+		return () => obs.disconnect();
+	}, [threshold]);
+	return { ref, inView };
 }
 
 const PORTS: readonly Port[] = [
-  { name: "Zig", sub: "where Bun started" },
-  { name: "Rust", sub: "where it landed" },
-  { name: "next?", sub: "whatever comes" },
+	{ name: "Zig", sub: "where Bun started" },
+	{ name: "Rust", sub: "where it landed" },
+	{ name: "next?", sub: "whatever comes" },
 ];
 
 export default function SpecSurvivesPort() {
-  useStyles();
-  const { ref, inView } = useInView<HTMLDivElement>();
-  const [i, setI] = useState(0);
+	useStyles();
+	const { ref, inView } = useInView<HTMLDivElement>();
+	const [i, setI] = useState(0);
 
-  useEffect(() => {
-    if (!inView) return;
-    const id = setInterval(() => setI((x) => (x + 1) % PORTS.length), 1600);
-    return () => clearInterval(id);
-  }, [inView]);
+	useEffect(() => {
+		if (!inView) return;
+		const id = setInterval(() => setI((x) => (x + 1) % PORTS.length), 1600);
+		return () => clearInterval(id);
+	}, [inView]);
 
-  return (
-    <div className={`ts ${inView ? "ts-in" : ""}`} ref={ref}>
-      <p className="ts-cap">The invariant · what actually survives a rewrite</p>
-      <div className="ts-spec-wrap ts-rise">
-        <div className="ts-spec-bar">
-          <b>The test suite — the spec</b>
-          <span>constant · never ports</span>
-        </div>
-        <div className="ts-invariant">
-          ↓ every implementation below must satisfy the same suite above ↓
-        </div>
-        <div className="ts-langs">
-          {PORTS.map((p, idx) => (
-            <div key={p.name} className={`ts-lang ${idx === i ? "on" : ""}`}>
-              <div className="ts-lang-name">{p.name}</div>
-              <div className="ts-lang-sub">{p.sub}</div>
-            </div>
-          ))}
-        </div>
-        <div className="ts-morph ts-mono">
-          implementation is disposable — the spec is the product
-        </div>
-      </div>
-    </div>
-  );
+	return (
+		<div className={`ts ${inView ? "ts-in" : ""}`} ref={ref}>
+			<p className="ts-cap">The invariant · what actually survives a rewrite</p>
+			<div className="ts-spec-wrap ts-rise">
+				<div className="ts-spec-bar">
+					<b>The test suite — the spec</b>
+					<span>constant · never ports</span>
+				</div>
+				<div className="ts-invariant">
+					↓ every implementation below must satisfy the same suite above ↓
+				</div>
+				<div className="ts-langs">
+					{PORTS.map((p, idx) => (
+						<div key={p.name} className={`ts-lang ${idx === i ? "on" : ""}`}>
+							<div className="ts-lang-name">{p.name}</div>
+							<div className="ts-lang-sub">{p.sub}</div>
+						</div>
+					))}
+				</div>
+				<div className="ts-morph ts-mono">
+					implementation is disposable — the spec is the product
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/src/content/blog/deploy-android-app-2025-12-tester-rule.mdx
+++ b/src/content/blog/deploy-android-app-2025-12-tester-rule.mdx
@@ -26,7 +26,7 @@ keywords:
   - android
   - app development
   - flutter
-canonicalUrl: /blog/deploying-android-apps-in-2025-a-solo-devs-journey
+canonicalUrl: /blog/deploy-android-app-2025-12-tester-rule/
 featured: true
 excerpt: >-
   In this post, I share the painful journey of deploying my Flutter-built

--- a/src/content/blog/flutter-gradle-task-assembledebug-stuck-solution.mdx
+++ b/src/content/blog/flutter-gradle-task-assembledebug-stuck-solution.mdx
@@ -27,7 +27,7 @@ keywords:
   - flutter running gradle task
   - android
   - mobile development
-canonicalUrl: /blog/fixing-flutter-stuck-at-running-gradle-task-assembledebug-quick-solution
+canonicalUrl: /blog/flutter-gradle-task-assembledebug-stuck-solution/
 featured: false
 excerpt: "Flutter stuck at 'Running Gradle task assembleDebug' forever? This guide fixes it on Windows, Mac, and Linux — Gradle cache issues, exit code 1, and slow first builds."
 ---

--- a/src/content/blog/vercel-playwright-deployment-error-debugging.mdx
+++ b/src/content/blog/vercel-playwright-deployment-error-debugging.mdx
@@ -21,8 +21,7 @@ keywords:
   - software development
   - blog
   - thought-process
-canonicalUrl: >-
-  /blog/the-vercel-playwright-puzzle-when-headless-browsers-go-rogue-on-deployment-the-full-debugging-saga
+canonicalUrl: /blog/vercel-playwright-deployment-error-debugging/
 featured: false
 excerpt: >-
   How a simple Playwright integration turned into a multi-day battle with Vercel


### PR DESCRIPTION
## Why
Google Search Console surfaced conflicting user-declared canonicals for three blog URLs. Google had already selected the actual trailing-slash routes, splitting the site’s canonical signals.

## Evidence
- Search Console analysis: final web data, 2026-04-28 to 2026-07-26
- URL Inspection confirmed the Flutter page was not indexed because Google selected its actual route over the stale canonical.
- Playwright was indexed but Google selected the trailing-slash route over the stale canonical.
- Android had a stale canonical target and is not indexed.

## Changes
- Normalize the three affected MDX `canonicalUrl` fields to their published trailing-slash routes.
- Set Astro trailing-slash policy to `always` so generated URL signals stay consistent.

## Expected outcome
Consolidate canonical signals and reduce duplicate URL ambiguity for the affected posts.

## Validation
- `git diff --check` passed.
- Targeted canonical metadata assertion passed.
- Independent review passed with no security or correctness findings.
- `bun run lint` was run without building. It reports 9 existing issues in unrelated React components; this patch changes no affected files.

No build, dev server, preview, or deployment was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized site URLs to consistently include trailing slashes.
  * Updated canonical URLs for several blog articles to their current paths, improving link consistency and search indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->